### PR TITLE
[modify][#20] DB에 is_deleted 추가

### DIFF
--- a/server/src/__tests__/login.test.ts
+++ b/server/src/__tests__/login.test.ts
@@ -4,18 +4,28 @@ process.env.NODE_ENV = 'test';
 import request from 'supertest';
 import app from '..';
 import {makeSalt, convertPassword} from '../service/pwCrypto';
-import {resetTable, addMember, MemberModel, poolEnd} from '../repository/mysql';
+import {resetTable, addMember, MemberModel, poolEnd, addMemberDeleted} from '../repository/mysql';
 
 const TEST_EMAIL = "abc@abc.com";
 const TEST_PASSWORD = "abc";
 
+const TEST_EMAIL_DELETED = "deleted@abc.com";
+const TEST_PASSWORD_DELETED = "deleted";
+
 beforeAll(async () => {
     await resetTable('member_tb');
-    const result: {password: string, salt: string} = await convertPassword(TEST_PASSWORD);
+    let result: {password: string, salt: string} = await convertPassword(TEST_PASSWORD);
     const member = new MemberModel({
-        no: 0, email:TEST_EMAIL, password: result.password, salt:result.salt, created_at : new Date()
+        no: 0, email:TEST_EMAIL, password: result.password, salt:result.salt, created_at : new Date(), is_deleted:false
     });
+
+    result = await convertPassword(TEST_PASSWORD_DELETED);
+    const deletedMember = new MemberModel({
+        no: 0, email:TEST_EMAIL_DELETED, password: result.password, salt:result.salt, created_at : new Date(), is_deleted:true
+    });
+
     await addMember(member);
+    await addMemberDeleted(deletedMember);
 });
 
 describe('POST /login은', () => {
@@ -48,6 +58,11 @@ describe('POST /login은', () => {
                 .send({email: TEST_EMAIL, password :`${TEST_PASSWORD}1241241}`})
                 .expect(400).end(done);
         });
+        test('삭제된 유저', done => {
+            request(app).post('/login')
+                .send({email: TEST_EMAIL_DELETED, password :TEST_PASSWORD_DELETED})
+                .expect(400).end(done);
+        })
     });
 });
 

--- a/server/src/repository/mysql/index.ts
+++ b/server/src/repository/mysql/index.ts
@@ -1,5 +1,5 @@
 import {
-    addMember, addGroup, resetTable, getMemberInfo, poolEnd
+    addMember, addGroup, resetTable, getMemberInfo, poolEnd, addMemberDeleted
 } from './mysql.repository';
 
 import {
@@ -11,7 +11,7 @@ import {
 } from './mysql.collection';
 
 export {
-    addMember, addGroup, resetTable, getMemberInfo, poolEnd,
+    addMember, addGroup, resetTable, getMemberInfo, poolEnd, addMemberDeleted,
     MemberModel,
     GroupModel,
     GroupMemberModel,

--- a/server/src/repository/mysql/mysql.collection.ts
+++ b/server/src/repository/mysql/mysql.collection.ts
@@ -6,13 +6,18 @@ class MemberModel {
     password: string;
     salt: string;
     createdAt: Date;
+    isDeleted: boolean;
 
-    constructor({no, email, password, salt, created_at} : {no:number, email:string, password:string, salt:string, created_at:Date}) {
+    constructor(
+        {no, email, password, salt, created_at, is_deleted} : 
+        {no:number, email:string, password:string, salt:string, created_at:Date, is_deleted:boolean}
+        ) {
         this.no = no;
         this.email = email;
         this.password = password;
         this.salt = salt,
         this.createdAt = created_at;
+        this.isDeleted = is_deleted;
     }
 }
 
@@ -22,11 +27,16 @@ class GroupModel {
     no: number;
     title: string;
     createdAt: Date;
+    isDeleted: boolean;
     
-    constructor({no, title, created_at} : {no: number, title: string, created_at: Date}) {
+    constructor(
+        {no, title, created_at, is_deleted} : 
+        {no: number, title: string, created_at: Date, is_deleted: boolean}
+        ) {
         this.no = no;
         this.title = title;
         this.createdAt = created_at;
+        this.isDeleted = is_deleted;
     }
 }
 
@@ -37,12 +47,17 @@ class GroupMemberModel {
     groupNo: number;
     memberNo: number;
     createdAt: Date;
+    isDeleted: boolean;
 
-    constructor({no, group_no, member_no, created_at} : {no: number, group_no: number, member_no: number, created_at: Date}) {
+    constructor({
+        no, group_no, member_no, created_at, is_deleted} : 
+        {no: number, group_no: number, member_no: number, created_at: Date, is_deleted: boolean}
+        ) {
         this.no = no;
         this.groupNo = group_no;
         this.memberNo = member_no;
         this.createdAt = created_at;
+        this.isDeleted = is_deleted;
     }
 }
 
@@ -53,13 +68,18 @@ class ColumnModel {
     orderNo: number;
     title: string;
     createdAt: Date;
+    isDeleted: boolean;
     groupNo: number;
 
-    constructor({no, order_no, title, created_at, group_no}: {no: number, order_no: number, title: string, created_at: Date, group_no: number}) {
+    constructor(
+        {no, order_no, title, created_at, group_no, is_deleted}: 
+        {no: number, order_no: number, title: string, created_at: Date, is_deleted: boolean, group_no: number}
+        ) {
         this.no = no;
         this.orderNo = order_no;
         this.title = title;
         this.createdAt = created_at;
+        this.isDeleted = is_deleted;
         this.groupNo = group_no;
     }
 }
@@ -71,14 +91,19 @@ class CardModel {
     content: string;
     orderNo: number;
     createdAt: Date;
+    isDeleted: boolean;
     authorNo: number;
     columnNo: number;
 
-    constructor({no, content, order_no, created_at, author_no, column_no}: {no: number, content: string, order_no: number, created_at: Date, author_no: number, column_no: number}) {
+    constructor(
+        {no, content, order_no, created_at, is_deleted, author_no, column_no}: 
+        {no: number, content: string, order_no: number, created_at: Date, is_deleted: boolean, author_no: number, column_no: number}
+        ) {
         this.no = no;
         this.content = content;
         this.orderNo = order_no;
         this.createdAt = created_at;
+        this.isDeleted = is_deleted;
         this.authorNo = author_no;
         this.columnNo = column_no;
     }
@@ -91,12 +116,3 @@ export {
     ColumnModel,
     CardModel
 };
-// const models = {
-//     MemberModel,
-//     GroupModel,
-//     GroupMemberModel,
-//     ColumnModel,
-//     CardModel
-// };
-
-// export default models;

--- a/server/src/repository/mysql/mysql.repository.ts
+++ b/server/src/repository/mysql/mysql.repository.ts
@@ -24,6 +24,10 @@ async function addMember(member: MemberModel) {
     const {email, password, salt} = member;
     return await pool.execute(query.INSERT_MEMBER_TB, [email, password, salt]);
 }
+async function addMemberDeleted(member: MemberModel) {
+    const {email, password, salt} = member;
+    return await pool.execute(query.INSERT_MEMBER_TB_DELETED, [email, password, salt]);
+}
 
 async function addGroup(group: GroupModel) {
     const {title} = group;
@@ -34,11 +38,22 @@ async function resetTable(tableName: string) {
     const resetQuery = query.RESET_TB.replace('?', tableName);
     return await pool.execute(resetQuery);
 }
-async function getMemberInfo(email: string) {
+async function getMemberInfo(email: string): MemberModel {
     const [rows, fields] = await pool.execute<RowDataPacket[]>(query.SELECT_MEMBER, [email]);
     if(rows.length === 0) return null;
-    const memberInfo = rows[0];
-    return memberInfo;
+    
+    const info = rows[0];
+
+    const memberModel = new MemberModel({
+        no : info.no, 
+        email : info.email, 
+        password : info.password, 
+        salt : info.salt, 
+        created_at : info.created_at, 
+        is_deleted : info.is_deleted
+    });
+    
+    return memberModel;
 }
 
 function poolEnd() {
@@ -47,6 +62,7 @@ function poolEnd() {
 
 export {
     addMember,
+    addMemberDeleted,
     addGroup,
     getMemberInfo,
     resetTable,

--- a/server/src/repository/mysql/query.ts
+++ b/server/src/repository/mysql/query.ts
@@ -4,16 +4,18 @@ const CREATE_MEMBER_TB: string = `CREATE TABLE member_tb (
     password VARCHAR(255) NOT NULL,
     salt VARCHAR(255) NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_deleted bool default false,
     PRIMARY KEY(no)
 );`
 
 const INSERT_MEMBER_TB: string = `INSERT INTO member_tb(email, password, salt) VALUES(?, ?, ?);`;
-
+const INSERT_MEMBER_TB_DELETED: string = `INSERT INTO member_tb(email, password, salt, is_deleted) VALUES(?, ?, ?, true);`;
 
 const CREATE_GROUP_TB: string = `CREATE TABLE group_tb (
     no INT NOT NULL AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_deleted bool default false,
     PRIMARY KEY(no)
 );`;
 
@@ -24,6 +26,7 @@ const CREATE_GROUP_MEMBER_TB: string = `CREATE TABLE group_member_tb (
     group_no INT NOT NULL,
     member_no INT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_deleted bool default false,
     PRIMARY KEY(no),
     FOREIGN KEY(group_no) REFERENCES group_tb(no),
     FOREIGN KEY(member_no) REFERENCES member_tb(no)
@@ -39,6 +42,7 @@ const CREATE_COLUMN_TB: string = `CREATE TABLE column_tb (
     order_no INT NOT NULL,
     title VARCHAR(255) NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_deleted bool default false,
     group_no INT NOT NULL,
     PRIMARY KEY(no),
     FOREIGN KEY(group_no) REFERENCES group_tb(no)
@@ -54,6 +58,7 @@ const CREATE_CARD_TB: string = `CREATE TABLE card_tb (
     content VARCHAR(255) NOT NULL,
     order_no INT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_deleted bool default false,
     member_no INT  NOT NULL,
     column_no INT NOT NULL,
     PRIMARY KEY(no),
@@ -73,6 +78,7 @@ const CREATE_ACTIVITY_TB: string = `CREATE TABLE activity_tb (
     from_column_no INT NOT NULL,
     to_column_no INT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_deleted bool default false,
 
     PRIMARY KEY(no),
     FOREIGN KEY(member_no) REFERENCES member_tb(no),
@@ -94,6 +100,7 @@ const SELECT_MEMBER: string = `select * from member_tb where email = ?`;
 export default {
     CREATE_MEMBER_TB,
     INSERT_MEMBER_TB,
+    INSERT_MEMBER_TB_DELETED,
 
     CREATE_GROUP_TB,
     INSERT_GROUP_TB,

--- a/server/src/service/checker.ts
+++ b/server/src/service/checker.ts
@@ -6,6 +6,7 @@ async function checkMember(email: string, password: string): Promise<boolean> {
 
     const memberInfo = await getMemberInfo(email);    
     if(!memberInfo) return false;
+    if(memberInfo.isDeleted) return false;
 
     const convertedPassword = await convertPasswordWithSalt(password, memberInfo.salt);
     return  convertedPassword === memberInfo.password;

--- a/server/src/service/memberManager.ts
+++ b/server/src/service/memberManager.ts
@@ -5,7 +5,7 @@ async function signupMember(email: string, password: string) {
     try {
         const salt = await makeSalt();
         const convertedPassword = await convertPasswordWithSalt(password, salt);
-        const obj = {no: 0, email, password: convertedPassword, salt, created_at: new Date()};
+        const obj = {no: 0, email, password: convertedPassword, salt, created_at: new Date(), is_deleted: false};
         const newMember = new MemberModel(obj);
         
         await addMember(newMember);


### PR DESCRIPTION
삭제 관련해서 is_deleted (bool)를 추가했다.
bool 타입은 mysql에서 tinyint로 표현된다.

모든 테이블이 다 넣었기 때문에 변경사항이 추가로 생겼다.

mysql.collection의 모든 모델들은 전부 is_deleted가 추가 되었다.
mysql.repository 로그인 로직에서 is_deleted가 반영되었다.
query.ts에서 is_deleted 관련해서 쿼리가 수정되었다.

테스트 관련해서도 추가로 변경이 되었다.
먼저 로그인 로직에서 is_deleted를 체크하도록 변경되었다.
또한 그에 대한 테스트도 추가되었다.

mysql.repository에서 getMemberInfo의 경우 삭제된 유저에 대해서도 모델을 반환하도록 만들었다. 이렇게 한 이유는 삭제된 유저라도 일단 관리자 입장에서는 쿼리가 아니라 값을 뽑아서 다뤄야 할 경우가 생길수 있기 때문이다.